### PR TITLE
fix(tooling): close rename blind spot in asset hash check

### DIFF
--- a/.github/scripts/check-hashes.sh
+++ b/.github/scripts/check-hashes.sh
@@ -3,8 +3,11 @@
 #
 # (a) every tracked file with a .<sha256>. token in its name hashes to
 #     exactly that token;
-# (b) every hashed asset referenced by _header.html, errdocs/err.html and
-#     site.webmanifest exists on disk;
+# (b) every hashed asset referenced by any tracked text file (templates,
+#     stylesheets, articles) exists on disk — referencing files are
+#     discovered, not hardcoded, so renames cannot leave stale references
+#     behind; vendored trees are skipped (FONTLOG.txt holds historical
+#     commit-pinned permalinks that are valid but not present on disk);
 # (c) _header.html and errdocs/err.html agree on the hash tokens they
 #     reference (compared by basename, since the two files may legitimately
 #     use different path prefixes for the same asset).
@@ -37,14 +40,18 @@ refs() {
   grep -oE '[A-Za-z0-9_/.-]*\.[0-9a-f]{64}\.[A-Za-z0-9.]+' "$1" | sort -u
 }
 
-for src in _header.html errdocs/err.html site.webmanifest; do
-  [ -f "$src" ] || { fail "expected source file missing: $src"; continue; }
+for src in $(git grep -I -l -E '\.[0-9a-f]{64}\.' -- \
+  ':!fonts/' ':!stagit/' ':!migration/' ':!pubkeys/'); do
   for ref in $(refs "$src"); do
     [ -f "${ref#/}" ] || fail "$src references missing asset: $ref"
   done
 done
 
 # --- (c) header and errdocs reference identical hash tokens ----------------
+for src in _header.html errdocs/err.html; do
+  [ -f "$src" ] || fail "expected template missing: $src"
+done
+
 tokens() {
   refs "$1" | sed 's|.*/||' | sort -u
 }


### PR DESCRIPTION
## Summary

Follow-up to #6, fixing the one substantive finding from its post-merge review: the hash-integrity check validated references only in three hardcoded files, so renaming a hashed asset referenced from an article (30+ image refs across 4 articles) or from the stylesheet's font `url()`s passed all checks while breaking the site.

## Changes

- Check (b) now discovers referencing files via `git grep` over tracked text files instead of a hardcoded list, with vendored trees excluded (`fonts/*/FONTLOG.txt` carries commit-pinned permalinks that are valid without existing on disk).
- The template existence guard the hardcoded list implicitly provided is re-added explicitly before check (c).

## Testing

- Clean tree passes; a hash-preserving rename of an article-referenced image fails check (b) and only check (b) (check (a) stays green since the hash is still valid), then passes after restore.
- `pre-commit run --all-files` green.