### PR TITLE
fix(tooling): protect asset files from editorconfig normalization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,10 @@ indent_style = tab
 [{fonts,stagit,migration,pubkeys}/**]
 insert_final_newline = false
 trim_trailing_whitespace = false
+
+# Binary and hashed image/icon assets anywhere in the tree: an editor save
+# must never alter their bytes — content-hashed filenames break otherwise
+# (favicon.<hash>.svg legitimately lacks a final newline).
+[*.{png,webp,svg,ico,woff2}]
+insert_final_newline = false
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Closes the editor-side half of a review finding from #6: the .editorconfig trim/newline exception covered only the four vendored directories, leaving root-level hashed assets (favicon.<hash>.svg verifiably lacks a final newline) exposed to editor-save normalization that would break their content hashes.

## Changes

- Disable insert_final_newline and trim_trailing_whitespace for png/webp/svg/ico/woff2 everywhere in the tree.

## Testing

- The pre-commit gate (which already protected these at commit time via the hashed-filename exclude) remains green; this change only stops editorconfig-honoring editors from altering asset bytes on save.